### PR TITLE
[FEATURE] Improve the footer of the webpage #21

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,7 +6,7 @@ import routes from './Router/Routes';
 const App = () => {
   return (
     // wrapped routes with an all parent div with the background gradient
-    //changes h to min height bc of fixed h overlaping was occuuring on pages
+   
     <div className="app w-screen h-auto min-h-[100vh] [background:radial-gradient(125%_125%_at_50%_10%,#000_40%,#63e_100%)]">
       <Router routes={routes} />
     </div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,7 +6,8 @@ import routes from './Router/Routes';
 const App = () => {
   return (
     // wrapped routes with an all parent div with the background gradient
-    <div className="app w-screen h-screen [background:radial-gradient(125%_125%_at_50%_10%,#000_40%,#63e_100%)]">
+    //changes h to min height bc of fixed h overlaping was occuuring on pages
+    <div className="app w-screen h-auto min-h-[100vh] [background:radial-gradient(125%_125%_at_50%_10%,#000_40%,#63e_100%)]">
       <Router routes={routes} />
     </div>
   )

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -6,7 +6,7 @@ export default function Footer() {
   const isMobile = useMediaQuery("(max-width: 768px)");
 
   return (
-    // removed absolute position from footer bc it was causing problem on home page
+   
     <footer className="  mt-5   w-full footer text-white py-4">
       <ul className="list-none flex gap-4 sm:gap-10 justify-center items-center">
         <li>

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -6,7 +6,8 @@ export default function Footer() {
   const isMobile = useMediaQuery("(max-width: 768px)");
 
   return (
-    <footer className="absolute bottom-0 left-0 right-0 w-full footer text-white pb-4 pt-4">
+    // removed absolute position from footer bc it was causing problem on home page
+    <footer className="  mt-5   w-full footer text-white py-4">
       <ul className="list-none flex gap-4 sm:gap-10 justify-center items-center">
         <li>
           <a

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -36,7 +36,7 @@ export default function Home() {
 
   return (
     <>
-    {/* problem was due to absolute of footer to remove it on this page we have to give min h to body  */}
+    
       <div className="flex justify-center items-start min-h-[80vh]">
         <div className="text-white text-center mt-36 font-sans text-8xl">
           <p className="max-[400px]:text-4xl text-4xl md:text-7xl font-extrabold bg-clip-text text-transparent bg-[linear-gradient(to_right,theme(colors.indigo.400),theme(colors.indigo.100),theme(colors.sky.400),theme(colors.fuchsia.400),theme(colors.sky.400),theme(colors.indigo.100),theme(colors.indigo.400))] bg-[length:200%_auto] animate-gradient">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -36,7 +36,8 @@ export default function Home() {
 
   return (
     <>
-      <div className="flex justify-center items-start">
+    {/* problem was due to absolute of footer to remove it on this page we have to give min h to body  */}
+      <div className="flex justify-center items-start min-h-[80vh]">
         <div className="text-white text-center mt-36 font-sans text-8xl">
           <p className="max-[400px]:text-4xl text-4xl md:text-7xl font-extrabold bg-clip-text text-transparent bg-[linear-gradient(to_right,theme(colors.indigo.400),theme(colors.indigo.100),theme(colors.sky.400),theme(colors.fuchsia.400),theme(colors.sky.400),theme(colors.indigo.100),theme(colors.indigo.400))] bg-[length:200%_auto] animate-gradient">
             The Fastest Way


### PR DESCRIPTION
Fix Footer Overlay Issue on Smaller Screens

The issue of the footer overlapping with the content on smaller screens was caused by the fixed size of the page and the absolute positioning of the footer. When the content height increased beyond the available screen space, the footer would overlay on top of it.
Solution:
- Removed the `absolute` positioning from the footer to allow it to behave more responsively.
- Set the page's `min-height` to `100vh` to ensure the content takes up the full viewport height, preventing content from overflowing.
- Applied a `min-height` to the home page content to ensure it acquires enough space without causing an overflow, thus preserving the footer's position.

This approach resolves the footer overlay issue while maintaining a flexible and responsive layout across different screen sizes.

this is the video :
https://github.com/user-attachments/assets/cc2cbd38-7119-43c7-89b9-12a22e25390d




